### PR TITLE
Update examples for HELICS 2.1.1 release

### DIFF
--- a/cpp/comboFederate1/comboFed.cpp
+++ b/cpp/comboFederate1/comboFed.cpp
@@ -37,12 +37,12 @@ int main (int argc, char *argv[])
     auto ret = app.helics_parse (argc, argv);
 
     helics::FederateInfo fi;
-    if (ret == helics::helicsCLI11App::parse_return::help_return)
+    if (ret == helics::helicsCLI11App::parse_output::help_call)
     {
         fi.loadInfoFromArgs ("--help");
         return 0;
     }
-    else if (ret != helics::helicsCLI11App::parse_return::ok)
+    else if (ret != helics::helicsCLI11App::parse_output::ok)
     {
         return -1;
     }

--- a/cpp/filterFederate1/filterFed.cpp
+++ b/cpp/filterFederate1/filterFed.cpp
@@ -31,7 +31,7 @@ int main (int argc, char *argv[])
     app.add_option ("--dropprob", dropprob, "the probability a message will be dropped, only used with filtertype=random_drop");
 
     auto ret = app.helics_parse (argc, argv);
-    if (ret != helics::helicsCLI11App::parse_return::ok)
+    if (ret != helics::helicsCLI11App::parse_output::ok)
     {
         return -1;
     }

--- a/cpp/messageFederate1/messageFed.cpp
+++ b/cpp/messageFederate1/messageFed.cpp
@@ -27,12 +27,12 @@ int main (int argc, char *argv[])
     auto ret = app.helics_parse (argc, argv);
 
     helics::FederateInfo fi;
-    if (ret == helics::helicsCLI11App::parse_return::help_return)
+    if (ret == helics::helicsCLI11App::parse_output::help_call)
     {
         fi.loadInfoFromArgs ("--help");
         return 0;
     }
-    else if (ret == helics::helicsCLI11App::parse_return::ok)
+    else if (ret == helics::helicsCLI11App::parse_output::ok)
     {
         return -1;
     }

--- a/cpp/messageFederate1/messageFedObj.cpp
+++ b/cpp/messageFederate1/messageFedObj.cpp
@@ -27,12 +27,12 @@ int main (int argc, char *argv[])
     auto ret = app.helics_parse (argc, argv);
 
     helics::FederateInfo fi;
-    if (ret == helics::helicsCLI11App::parse_return::help_return)
+    if (ret == helics::helicsCLI11App::parse_output::help_call)
     {
         fi.loadInfoFromArgs ("--help");
         return 0;
     }
-    else if (ret == helics::helicsCLI11App::parse_return::ok)
+    else if (ret == helics::helicsCLI11App::parse_output::ok)
     {
         return -1;
     }

--- a/cpp/valueFederate1/valueFed.cpp
+++ b/cpp/valueFederate1/valueFed.cpp
@@ -23,12 +23,12 @@ int main (int argc, const char * const *argv)
     auto ret = app.helics_parse (argc, argv);
     
     helics::FederateInfo fi;
-    if (ret == helics::helicsCLI11App::parse_return::help_return)
+    if (ret == helics::helicsCLI11App::parse_output::help_call)
     {
         fi.loadInfoFromArgs ("--help");
         return 0;
     }
-    else if (ret != helics::helicsCLI11App::parse_return::ok)
+    else if (ret != helics::helicsCLI11App::parse_output::ok)
     {
         return -1;
     }


### PR DESCRIPTION
Updates the HELICS examples for the HELICS 2.1.1 due to a non-public/stable API change (helicsCLI11App).