### PR TITLE
Update the used libraries/code to be more accurate

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -14,13 +14,12 @@ If you would like to contribute to the HELICS-examples, HELICS, or any of the GM
  - Brian Palmentier
 
 ### Other
-[Bryan Richardson](https://github.com/activeshadow) Active Shadow LLC
-[Cody Rooks](https://github.com/rookscody) University of Tennessee (Knoxville)
+ - [Bryan Richardson](https://github.com/activeshadow) Active Shadow LLC
+ - [Cody Rooks](https://github.com/rookscody) University of Tennessee (Knoxville)
 
 ## Used Libraries or Code
 ### [HELICS](https://github.com/GMLC-TDC/HELICS)  
-Most of the original code for this library was pulled from use inside HELICS. Several examples were initially included in the HELICS repo but were pulled out when this repo was created  HELICS is released with a BSD-3-Clause license.
+Most of the original code for this repository was pulled from use inside HELICS. Several examples were initially included in the HELICS repo but were pulled out when this repo was created. HELICS is released with a BSD-3-Clause license.
 
-### cmake scripts
-Several cmake scripts came from other sources and were either used or modified for use in HELICS.
- - CLI11 [CLI11](https://github.com/CLIUtils/CLI11)  while CLI11 was not used directly many of the CI scripts and structure were borrowed to set up the CI builds.  
+### CLI11
+The `Native.<OS>` job names used on Azure Pipelines came from the [CLI11](https://github.com/CLIUtils/CLI11) CI setup.


### PR DESCRIPTION

### Summary
If merged this pull request will make the used libraries and code section of the CONTRIBUTORS more accurately reflect what came from other sources.

### Proposed changes
- Format "other" individual  contributors as a list
- Change description of HELICS as being the original source of code for this library to repository, to reflect that the examples repository isn't a library
- Remove the CMake scripts section (seems to be a line from HELICS contributors that apply to the separated out examples)
- Update what part of the CI setup came from CLI11
