### PR TITLE
Fix Configuration Issue with `fundamental_message_comm/endpoints` Example (Fixes #96)

### DIFF
--- a/user_guide_examples/fundamental/fundamental_message_comm/endpoints/BatteryConfig.json
+++ b/user_guide_examples/fundamental/fundamental_message_comm/endpoints/BatteryConfig.json
@@ -2,7 +2,7 @@
   "name": "Battery",
   "log_level": "warning",
   "core_type": "zmq",
-  "period": 60.0,
+  "period": 60,
   "offset": 10,
   "uninterruptible": false,
   "terminate_on_error": true,


### PR DESCRIPTION
<!--By submitting a pull request you are acknowledging that you have the right to license your code under the terms of this repositories license.  
Please review the [Contributing Guidelines](../CONTRIBUTING.md) for more details
Please make sure you fill the following sections. If this PR fixes an issue, please tag the issue number in the first section.
e.g. This fixes issue #123-->
### Summary
<!-- please finish the following statement -->
PR into `main` because `develop` seems inactive. If merged, this pull request will fix #96 by changing the data type in a configuration file from a float to an integer.

### Proposed changes
<!-- Describe the highlights of the proposed changes here -->
- For the example found under `user_guide_examples/fundamental/fundamental_message_comm/endpoints/`
- Change the `period` data in the file `BatteryConfig.json` from `60.0` to `60` in order to mitigate error.
