### PR TITLE
Fix market game invalid demand handling

### DIFF
--- a/python/market_game/battery.py
+++ b/python/market_game/battery.py
@@ -48,25 +48,30 @@ class Battery:
 def ensure_valid(value:float, current_consumption:float, battery:Battery)-> float:
     """ Ensure the value is within the valid range based on current demand and battery state.
     """
-    if value >= current_consumption + (BATTERY_CAPCITY-battery.current_charge()):
-        return current_consumption + (BATTERY_CAPCITY-battery.current_charge())
-    if value >= current_consumption + BATTERY_MAX_CHARGE:
-        return current_consumption + BATTERY_MAX_CHARGE
-    if value <= current_consumption -battery.current_charge():
-        return current_consumption - battery.current_charge()
-    if value <= current_consumption -BATTERY_MAX_DISCHARGE:
-        return current_consumption - BATTERY_MAX_DISCHARGE
-    return value
+    upper_bound = current_consumption + min(
+        BATTERY_MAX_CHARGE,
+        BATTERY_CAPCITY - battery.current_charge(),
+    )
+    lower_bound = current_consumption - min(
+        BATTERY_MAX_DISCHARGE,
+        battery.current_charge(),
+    )
+    return min(max(value, lower_bound), upper_bound)
 
 def check_valid(value:float, current_consumption:float, battery:Battery)-> str:
     """ check if the value of consumption is within the valid range based on current consumption and battery state.
     """
-    if value >= current_consumption + (BATTERY_CAPCITY-battery.current_charge()):
-        return "listed battery charge rate exceeds available battery storage capacity"
-    if value >= current_consumption + BATTERY_MAX_CHARGE:
+    remaining_capacity = BATTERY_CAPCITY - battery.current_charge()
+    max_charge = min(BATTERY_MAX_CHARGE, remaining_capacity)
+    max_discharge = min(BATTERY_MAX_DISCHARGE, battery.current_charge())
+    upper_bound = current_consumption + max_charge
+    lower_bound = current_consumption - max_discharge
+    if value > upper_bound:
+        if remaining_capacity < BATTERY_MAX_CHARGE:
+            return "listed battery charge rate exceeds available battery storage capacity"
         return "listed battery charge rate exceeds maximum charge rate"
-    if value <= current_consumption -battery.current_charge():
-        return "listed consumption exceeds available battery energy"
-    if value <= current_consumption -BATTERY_MAX_DISCHARGE:
+    if value < lower_bound:
+        if battery.current_charge() < BATTERY_MAX_DISCHARGE:
+            return "listed consumption exceeds available battery energy"
         return "listed consumption exceeds max battery discharge rate"
     return ""

--- a/python/market_game/market_maker.py
+++ b/python/market_game/market_maker.py
@@ -154,14 +154,14 @@ while current_time<24:
         warning=check_valid(load,fed.demand[hour], fed.battery)
         if warning:
             valid_load=ensure_valid(load,fed.demand[hour], fed.battery)
-            print(f"invalid demand received for fed {fed.name}={load} vs {valid_load} warning={warning}, recalculating with new value and assessing penalty")
             penaltyCost=20*abs(load-valid_load)
+            print(f"invalid demand received for fed {fed.name}={load} vs {valid_load} warning={warning}, recalculating with new value and assessing penalty={penaltyCost}")
             load=valid_load
        
         fed.battery.change(load-fed.demand[hour])
         fed.consume.append(load)
-        fed.hourCost.append(load*current_price)
-        print(f"hr {hour}: federate {fed.name} using {load} scheduled {fed.demand[hour]} battery at {fed.battery.energy} cost={load*current_price}")
+        fed.hourCost.append(load*current_price+penaltyCost)
+        print(f"hr {hour}: federate {fed.name} using {load} scheduled {fed.demand[hour]} battery at {fed.battery.energy} cost={load*current_price+penaltyCost}")
         total_load+=load
     loads.append(total_load)
     print(f"hr {hour}: total load {total_load} new  price = {current_price} ")

--- a/python/market_game/tests/check_battery_validation.py
+++ b/python/market_game/tests/check_battery_validation.py
@@ -1,0 +1,69 @@
+"""Checks for market-game battery validation helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+
+MARKET_GAME_DIR = Path(__file__).resolve().parents[1]
+if str(MARKET_GAME_DIR) not in sys.path:
+    sys.path.insert(0, str(MARKET_GAME_DIR))
+
+from battery import Battery, check_valid, ensure_valid
+
+
+def penalty_cost(proposed: float, valid: float) -> float:
+    return 20.0 * abs(proposed - valid)
+
+
+def run_check() -> None:
+    battery = Battery(0.0)
+    assert ensure_valid(100.0, 2.0, battery) == 7.0
+    assert check_valid(100.0, 2.0, battery) == (
+        "listed battery charge rate exceeds maximum charge rate"
+    )
+    assert penalty_cost(100.0, ensure_valid(100.0, 2.0, battery)) == 1860.0
+    battery.change(ensure_valid(100.0, 2.0, battery) - 2.0)
+    assert battery.energy == 5.0
+
+    battery = Battery(19.0)
+    assert ensure_valid(100.0, 2.0, battery) == 3.0
+    assert check_valid(100.0, 2.0, battery) == (
+        "listed battery charge rate exceeds available battery storage capacity"
+    )
+    assert penalty_cost(100.0, ensure_valid(100.0, 2.0, battery)) == 1940.0
+    battery.change(ensure_valid(100.0, 2.0, battery) - 2.0)
+    assert battery.energy == 20.0
+
+    battery = Battery(0.0)
+    assert ensure_valid(-100.0, 2.0, battery) == 2.0
+    assert check_valid(-100.0, 2.0, battery) == (
+        "listed consumption exceeds available battery energy"
+    )
+    assert penalty_cost(-100.0, ensure_valid(-100.0, 2.0, battery)) == 2040.0
+    battery.change(ensure_valid(-100.0, 2.0, battery) - 2.0)
+    assert battery.energy == 0.0
+
+    battery = Battery(20.0)
+    assert ensure_valid(-100.0, 12.0, battery) == 2.0
+    assert check_valid(-100.0, 12.0, battery) == (
+        "listed consumption exceeds max battery discharge rate"
+    )
+    assert penalty_cost(-100.0, ensure_valid(-100.0, 12.0, battery)) == 2040.0
+    battery.change(ensure_valid(-100.0, 12.0, battery) - 12.0)
+    assert battery.energy == 10.0
+
+    battery = Battery(0.0)
+    assert ensure_valid(7.0, 2.0, battery) == 7.0
+    assert check_valid(7.0, 2.0, battery) == ""
+    assert penalty_cost(7.0, ensure_valid(7.0, 2.0, battery)) == 0.0
+
+    battery = Battery(20.0)
+    assert ensure_valid(2.0, 12.0, battery) == 2.0
+    assert check_valid(2.0, 12.0, battery) == ""
+
+
+if __name__ == "__main__":
+    run_check()
+    print("battery validation: ok")


### PR DESCRIPTION
## Summary

This PR fixes invalid demand handling in the Python `market_game` example.

The current code clamps invalid house demand before updating the battery, but the clamp checks can return a value that still violates the battery rate limits when a submission violates multiple constraints at once. The market maker also computes an invalid-demand penalty but does not add it to the scored hourly cost.

This PR makes invalid-demand handling explicit and safe:

- Clamp submitted market demand against combined battery bounds.
- Ensure the clamped value is always safe for `Battery.change(...)`.
- Treat exact legal boundary values as valid.
- Apply the invalid-demand penalty to scored hourly cost.
- Add focused validation checks for edge cases.

## Validation

```bash
  python3 python/market_game/tests/check_battery_validation.py
```
## Downstream Workbench

I am also developing a downstream market-game workbench here:

https://github.com/RobertFrenken/HELICS-Examples-market_game

That repo separates broader simulator, evaluation, RL, and export experiments from the upstream-facing HELICS example. The goal is to upstream pieces in small, reviewable PRs rather than bundle the whole workbench into one change.

## Potential Future PRs

1. Dependency-free pure Python market rules and simulator with parity checks against the stock houses.
2. Baseline scenario evaluator for comparing house policies.
3. Optional weekly/new-profile/opponent scenario configuration.
4. Gymnasium adapter for optional RL experiments.
5. Optional RL training examples.
6. Export/deployment helpers for self-contained compute_demand(...) submissions.