### PR TITLE
Add pure-Python market game simulator checks

### DIFF
--- a/python/market_game/docs/simulation.md
+++ b/python/market_game/docs/simulation.md
@@ -1,0 +1,91 @@
+# Pure-Python Market Game Simulation
+
+The `simulation/` package mirrors the market-game rules without starting HELICS
+federates. It is useful for fast checks of pricing, battery validation, and
+strategy behavior before running a full co-simulation.
+
+This does not change the HELICS runtime behavior. The existing `market_maker.py`,
+`battery.py`, and house federates still run the official game. The simulator is
+an additional dependency-free path for tests, examples, and strategy checks.
+
+## Policy Interface
+
+Simulator policies use the same decision surface as house federates:
+
+```python
+compute_demand(price, hour, battery_charge, demand, price_history)
+```
+
+Arguments:
+
+- `price`: current market price in `$/kWh`
+- `hour`: current hour from `0` to `23`
+- `battery_charge`: current stored battery energy
+- `demand`: the full 24-hour base demand profile
+- `price_history`: prices seen so far, including the current hour
+
+The return value is the market-facing load for the current hour. Values above
+`demand[hour]` charge the battery. Values below `demand[hour]` discharge it.
+
+## Scope
+
+The simulator covers:
+
+- 24-hour episodes
+- the default `profile1` demand profile
+- generated `flat`, `random`, `spike`, `dspike`, and `profile_solar` profiles
+- the market price curve from `market_maker.py`
+- the one-hour price lag
+- battery capacity, charge-rate, and discharge-rate limits
+- invalid-demand clamping and penalty accounting
+
+The simulator intentionally does not start HELICS, create brokers, plot results,
+or load external strategy files.
+
+## Running Checks
+
+From the repository root:
+
+```bash
+python3 python/market_game/tests/check_simulation.py
+```
+
+The combined check runs the core and parity checks. You can also run them
+individually:
+
+```bash
+python3 python/market_game/tests/check_simulation_core.py
+python3 python/market_game/tests/check_simulation_parity.py
+```
+
+The core check validates rule helpers, demand profiles, battery clamping, price
+calculation, invalid-demand penalties, and input validation.
+
+The parity check runs the stock example policies through the pure-Python
+simulator and verifies the expected 24-hour totals:
+
+| House | Total market load | Total cost | Final battery |
+|---|---:|---:|---:|
+| `FlattenDemandHouse` | `127.0` | `$35.4467` | `7.0` |
+| `FullCycleHouse` | `120.0` | `$47.7467` | `0.0` |
+| `PriceAwareHouse` | `125.0` | `$21.9533` | `5.0` |
+
+## Example
+
+```python
+from python.market_game.simulation.simulator import run_episode
+
+
+class FollowDemandPolicy:
+    name = "FollowDemandHouse"
+
+    def reset(self):
+        pass
+
+    def compute_demand(self, price, hour, battery_charge, demand, price_history):
+        return demand[hour]
+
+
+result = run_episode([FollowDemandPolicy()])
+print(result.total_costs())
+```

--- a/python/market_game/market_game.md
+++ b/python/market_game/market_game.md
@@ -184,6 +184,22 @@ For a strategy-focused walkthrough of what those example houses actually do in a
 run, including hourly loads and costs, see
 [house_strategy_tutorial.md](/c:/CodeProjects/HELICS-Examples/python/market_game/house_strategy_tutorial.md).
 
+## Running The Pure-Python Checks
+
+The `simulation/` package mirrors the market-game rules without starting HELICS
+federates. It is useful for quick checks of pricing, battery validation, and
+strategy behavior. More details are in
+[docs/simulation.md](/c:/CodeProjects/HELICS-Examples/python/market_game/docs/simulation.md).
+
+From the repository root:
+
+```powershell
+python python/market_game/tests/check_simulation.py
+```
+
+The parity check verifies the expected 24-hour results for the stock example
+houses under the same `compute_demand(...)` interface used by the HELICS run.
+
 ## Files In This Example
 
 - [house_template.py](/c:/CodeProjects/HELICS-Examples/python/market_game/house_template.py):
@@ -202,3 +218,7 @@ run, including hourly loads and costs, see
   battery limits and validation helpers
 - [run_neighborhood.py](/c:/CodeProjects/HELICS-Examples/python/market_game/run_neighborhood.py):
   helper that builds `houses.json` for `helics run`
+- [docs/simulation.md](/c:/CodeProjects/HELICS-Examples/python/market_game/docs/simulation.md):
+  simulator behavior and parity-check details
+- [simulation/](/c:/CodeProjects/HELICS-Examples/python/market_game/simulation):
+  dependency-free rules and simulator for quick local checks

--- a/python/market_game/simulation/README.md
+++ b/python/market_game/simulation/README.md
@@ -1,0 +1,13 @@
+# Market Game Simulation
+
+This package contains dependency-free market-game rules and a pure-Python
+simulator that mirrors the 24-hour HELICS example without starting federates.
+
+See [../docs/simulation.md](../docs/simulation.md) for behavior details,
+expected parity results, and usage notes.
+
+Run the focused checks from the repository root with:
+
+```bash
+python3 python/market_game/tests/check_simulation.py
+```

--- a/python/market_game/simulation/__init__.py
+++ b/python/market_game/simulation/__init__.py
@@ -1,0 +1,59 @@
+"""Dependency-free pure-Python rules and simulator for the HELICS market game."""
+
+from .config import (
+    DEFAULT_CONFIG,
+    PROFILE1_DEMAND,
+    PROFILE_TYPES,
+    MarketGameConfig,
+    demand_profile,
+)
+from .rules import (
+    BatteryAction,
+    ClampResult,
+    action_to_market_load,
+    check_valid,
+    clamp_market_load,
+    compute_price_from_average_load,
+    compute_price_from_total_load,
+    ensure_valid,
+)
+from .simulator import (
+    BatteryState,
+    HourRecord,
+    HouseHourInput,
+    HouseHourResult,
+    HousePolicy,
+    MarketScenario,
+    SimHouse,
+    SimulationResult,
+    run_episode,
+    run_scenario,
+    step_market_hour,
+)
+
+__all__ = [
+    "BatteryAction",
+    "BatteryState",
+    "ClampResult",
+    "DEFAULT_CONFIG",
+    "HourRecord",
+    "HouseHourInput",
+    "HouseHourResult",
+    "HousePolicy",
+    "MarketScenario",
+    "MarketGameConfig",
+    "PROFILE1_DEMAND",
+    "PROFILE_TYPES",
+    "SimHouse",
+    "SimulationResult",
+    "action_to_market_load",
+    "check_valid",
+    "clamp_market_load",
+    "compute_price_from_average_load",
+    "compute_price_from_total_load",
+    "demand_profile",
+    "ensure_valid",
+    "run_episode",
+    "run_scenario",
+    "step_market_hour",
+]

--- a/python/market_game/simulation/config.py
+++ b/python/market_game/simulation/config.py
@@ -1,0 +1,147 @@
+"""Configuration objects and demand profiles for the market game."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import math
+import random
+
+
+PROFILE1_DEMAND = [
+    2,
+    1,
+    1,
+    1,
+    2,
+    4,
+    6,
+    8,
+    9,
+    7,
+    5,
+    4,
+    3,
+    4,
+    5,
+    7,
+    9,
+    12,
+    10,
+    7,
+    5,
+    4,
+    2,
+    2,
+]
+
+SOLAR_DEMAND_BASE = [
+    2,
+    2,
+    2,
+    2,
+    3,
+    4,
+    5,
+    2,
+    -4,
+    -6,
+    -7,
+    -8,
+    -7,
+    -6,
+    -3,
+    1,
+    4,
+    8,
+    10,
+    11,
+    10,
+    7,
+    5,
+    3,
+]
+
+PROFILE_TYPES = (
+    "profile1",
+    "profile_solar",
+    "flat",
+    "random",
+    "spike",
+    "dspike",
+)
+
+
+@dataclass(frozen=True)
+class MarketGameConfig:
+    """Rules/configuration for one market-game episode."""
+
+    episode_hours: int = 24
+    initial_price: float = 0.5
+    initial_battery: float = 0.0
+    battery_capacity: float = 20.0
+    max_charge: float = 5.0
+    max_discharge: float = 10.0
+    demand_profile: list[float] = field(default_factory=lambda: list(PROFILE1_DEMAND))
+    allow_negative_load: bool = True
+
+    def __post_init__(self) -> None:
+        """Fail fast on invalid rule settings before simulation starts."""
+        _validate_positive_int(self.episode_hours, "episode_hours")
+        _validate_finite(self.initial_price, "initial_price")
+        _validate_finite(self.initial_battery, "initial_battery")
+        _validate_positive_number(self.battery_capacity, "battery_capacity")
+        _validate_positive_number(self.max_charge, "max_charge")
+        _validate_positive_number(self.max_discharge, "max_discharge")
+        if not 0.0 <= self.initial_battery <= self.battery_capacity:
+            raise ValueError("initial_battery must be between 0 and battery_capacity")
+        if len(self.demand_profile) < self.episode_hours:
+            raise ValueError("demand_profile must contain at least episode_hours values")
+        for index, value in enumerate(self.demand_profile[: self.episode_hours]):
+            _validate_finite(value, f"demand_profile[{index}]")
+
+
+def demand_profile(profile_type: str, rng: random.Random | None = None) -> list[float]:
+    """Return a 24-hour base demand profile matching the HELICS market maker."""
+    rng = rng or random
+    if profile_type == "profile1":
+        return list(PROFILE1_DEMAND)
+    if profile_type == "profile_solar":
+        return [value * 3.0 for value in SOLAR_DEMAND_BASE]
+    if profile_type == "flat":
+        return [5] * 24
+    if profile_type == "random":
+        elements = [rng.random() for _ in range(24)]
+        multiplier = 120.0 / sum(elements)
+        return [value * multiplier for value in elements]
+    if profile_type == "spike":
+        profile = [4] * 24
+        profile[rng.randint(0, 23)] = 28
+        return profile
+    if profile_type == "dspike":
+        profile = [3] * 24
+        profile[rng.randint(0, 23)] += 24
+        profile[rng.randint(0, 23)] += 24
+        return profile
+    choices = ", ".join(PROFILE_TYPES)
+    raise ValueError(f"unknown demand profile {profile_type!r}; choices: {choices}")
+
+
+def _validate_positive_int(value: int, field_name: str) -> None:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError(f"{field_name} must be an integer >= 1")
+
+
+def _validate_positive_number(value: float, field_name: str) -> None:
+    _validate_finite(value, field_name)
+    if value <= 0.0:
+        raise ValueError(f"{field_name} must be > 0")
+
+
+def _validate_finite(value: float, field_name: str) -> None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{field_name} must be numeric")
+    if not math.isfinite(float(value)):
+        raise ValueError(f"{field_name} must be finite")
+
+
+DEFAULT_CONFIG = MarketGameConfig()

--- a/python/market_game/simulation/rules.py
+++ b/python/market_game/simulation/rules.py
@@ -1,0 +1,141 @@
+"""Market-game rule functions shared by HELICS scripts and simulation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import IntEnum
+import math
+from typing import Protocol
+
+from .config import DEFAULT_CONFIG, MarketGameConfig
+
+
+class BatteryLike(Protocol):
+    def current_charge(self) -> float:
+        """Return current stored energy."""
+
+
+class BatteryAction(IntEnum):
+    """Discrete battery posture for student examples and simple controllers."""
+
+    DISCHARGE = -1
+    NEUTRAL = 0
+    CHARGE = 1
+
+
+@dataclass(frozen=True)
+class ClampResult:
+    market_load: float
+    warning: str = ""
+
+
+def compute_price_from_average_load(average_market_load: float) -> float:
+    """Return the market price for one average market-facing load value."""
+    _finite_number(average_market_load, "average_market_load")
+    m = average_market_load
+    if m < 3.0:
+        return 0.1
+    if m < 6.0:
+        return 0.1 + 0.03 * (m - 3.0)
+    if m < 9.0:
+        return 0.19 + 0.1 * (m - 6.0)
+    if m < 13.0:
+        return 0.49 + 0.25 * (m - 9.0)
+    return 1.49 + 1.0 * (m - 13.0)
+
+
+def compute_price_from_total_load(total_market_load: float, house_count: int) -> float:
+    _finite_number(total_market_load, "total_market_load")
+    if house_count < 0:
+        raise ValueError("house_count must be >= 0")
+    if house_count == 0:
+        return 0.1
+    return compute_price_from_average_load(total_market_load / house_count)
+
+
+def clamp_market_load(
+    market_load: float,
+    base_demand: float,
+    battery_charge: float,
+    config: MarketGameConfig = DEFAULT_CONFIG,
+) -> ClampResult:
+    """Clamp a submitted market load to the game's battery constraints."""
+    _finite_number(market_load, "market_load")
+    _finite_number(base_demand, "base_demand")
+    _finite_number(battery_charge, "battery_charge")
+    remaining_capacity = config.battery_capacity - battery_charge
+    max_charge_delta = min(config.max_charge, remaining_capacity)
+    max_discharge_delta = min(config.max_discharge, battery_charge)
+    upper_bound = base_demand + max_charge_delta
+    lower_bound = base_demand - max_discharge_delta
+    if not config.allow_negative_load:
+        lower_bound = max(0.0, lower_bound)
+
+    warning = ""
+    if market_load > upper_bound:
+        if remaining_capacity < config.max_charge:
+            warning = "listed battery charge rate exceeds available battery storage capacity"
+        else:
+            warning = "listed battery charge rate exceeds maximum charge rate"
+    elif market_load < lower_bound:
+        if not config.allow_negative_load and lower_bound == 0.0 and market_load < 0.0:
+            warning = "listed market load is negative"
+        elif battery_charge < config.max_discharge:
+            warning = "listed consumption exceeds available battery energy"
+        else:
+            warning = "listed consumption exceeds max battery discharge rate"
+    elif not config.allow_negative_load and market_load < 0.0:
+        warning = "listed market load is negative"
+
+    clamped = min(max(market_load, lower_bound), upper_bound)
+    return ClampResult(clamped, warning)
+
+
+def action_to_market_load(
+    action: BatteryAction | int,
+    base_demand: float,
+    battery_charge: float,
+    config: MarketGameConfig = DEFAULT_CONFIG,
+) -> float:
+    """Convert a discrete battery action into a legal market-facing load."""
+    action = BatteryAction(action)
+    if action == BatteryAction.DISCHARGE:
+        proposed = base_demand - config.max_discharge
+    elif action == BatteryAction.NEUTRAL:
+        proposed = base_demand
+    else:
+        proposed = base_demand + config.max_charge
+    return clamp_market_load(proposed, base_demand, battery_charge, config).market_load
+
+
+def _battery_charge(battery: BatteryLike | float) -> float:
+    if isinstance(battery, int | float):
+        return float(battery)
+    return battery.current_charge()
+
+
+def _finite_number(value: float, field_name: str) -> None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{field_name} must be numeric")
+    if not math.isfinite(float(value)):
+        raise ValueError(f"{field_name} must be finite")
+
+
+def ensure_valid(
+    value: float,
+    base_demand: float,
+    battery: BatteryLike | float,
+    config: MarketGameConfig = DEFAULT_CONFIG,
+) -> float:
+    """Compatibility wrapper for the original ``battery.ensure_valid`` helper."""
+    return clamp_market_load(value, base_demand, _battery_charge(battery), config).market_load
+
+
+def check_valid(
+    value: float,
+    base_demand: float,
+    battery: BatteryLike | float,
+    config: MarketGameConfig = DEFAULT_CONFIG,
+) -> str:
+    """Compatibility wrapper for the original ``battery.check_valid`` helper."""
+    return clamp_market_load(value, base_demand, _battery_charge(battery), config).warning

--- a/python/market_game/simulation/simulator.py
+++ b/python/market_game/simulation/simulator.py
@@ -1,0 +1,301 @@
+"""Pure-Python simulator for the market game."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import math
+from typing import Protocol
+
+from .config import DEFAULT_CONFIG, MarketGameConfig
+from .rules import clamp_market_load, compute_price_from_average_load
+
+
+class HousePolicy(Protocol):
+    name: str
+
+    def reset(self) -> None:
+        """Reset any episode-local policy state."""
+
+    def compute_demand(
+        self,
+        price: float,
+        hour: int,
+        battery_charge: float,
+        demand: list[float],
+        price_history: list[float],
+    ) -> float:
+        """Return this hour's market-facing load."""
+
+
+@dataclass
+class BatteryState:
+    energy: float
+    config: MarketGameConfig = DEFAULT_CONFIG
+
+    def current_charge(self) -> float:
+        return self.energy
+
+    def change(self, delta: float) -> float:
+        if isinstance(delta, bool) or not isinstance(delta, (int, float)):
+            raise ValueError("battery delta must be numeric")
+        if not math.isfinite(float(delta)):
+            raise ValueError("battery delta must be finite")
+        eps = 1e-9
+        if delta < 0.0:
+            discharge = abs(delta)
+            if discharge > self.energy + eps:
+                raise ValueError("requested discharge exceeds current charge level")
+            if discharge > self.config.max_discharge + eps:
+                raise ValueError("requested discharge exceeds maximum discharge rate")
+            discharge = min(discharge, self.energy, self.config.max_discharge)
+            self.energy -= discharge
+        else:
+            if self.energy + delta > self.config.battery_capacity + eps:
+                raise ValueError("requested charge exceeds maximum capacity")
+            if delta > self.config.max_charge + eps:
+                raise ValueError("requested charge rate exceeds maximum rate")
+            delta = min(delta, self.config.battery_capacity - self.energy, self.config.max_charge)
+            self.energy += delta
+        return self.energy
+
+
+@dataclass
+class SimHouse:
+    policy: HousePolicy
+    demand: list[float]
+    battery: BatteryState
+    loads: list[float] = field(default_factory=list)
+    costs: list[float] = field(default_factory=list)
+    battery_history: list[float] = field(default_factory=list)
+    boundary_warnings: list[str] = field(default_factory=list)
+    clamps: int = 0
+
+    @property
+    def total_cost(self) -> float:
+        return sum(self.costs)
+
+    @property
+    def total_load(self) -> float:
+        return sum(self.loads)
+
+
+@dataclass(frozen=True)
+class MarketScenario:
+    """Policies and rules for one repeatable market-game scenario."""
+
+    policies: list[HousePolicy]
+    demand_profile: list[float] | None = None
+    initial_price: float | None = None
+    config: MarketGameConfig = DEFAULT_CONFIG
+
+
+@dataclass(frozen=True)
+class HouseHourInput:
+    """One house's proposed market load for a single hour."""
+
+    name: str
+    proposed_market_load: float
+    base_demand: float
+    battery: BatteryState
+
+
+@dataclass(frozen=True)
+class HouseHourResult:
+    """Effective result for one house after validation and accounting."""
+
+    name: str
+    proposed_market_load: float
+    market_load: float
+    base_demand: float
+    battery_charge: float
+    cost: float
+    energy_cost: float
+    penalty_cost: float = 0.0
+    invalid_load_adjustment: float = 0.0
+    warning: str = ""
+
+
+@dataclass
+class HourRecord:
+    hour: int
+    price: float
+    total_load: float
+    average_load: float
+    next_price: float
+    loads_by_house: dict[str, float]
+    batteries_by_house: dict[str, float]
+    costs_by_house: dict[str, float]
+    energy_costs_by_house: dict[str, float] = field(default_factory=dict)
+    penalties_by_house: dict[str, float] = field(default_factory=dict)
+    invalid_load_adjustments_by_house: dict[str, float] = field(default_factory=dict)
+    proposed_loads_by_house: dict[str, float] = field(default_factory=dict)
+    warnings_by_house: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class SimulationResult:
+    houses: list[SimHouse]
+    records: list[HourRecord]
+    price_history: list[float]
+
+    def total_costs(self) -> dict[str, float]:
+        return {house.policy.name: house.total_cost for house in self.houses}
+
+    def total_loads(self) -> dict[str, float]:
+        return {house.policy.name: house.total_load for house in self.houses}
+
+
+def run_episode(
+    policies: list[HousePolicy],
+    demand_profile: list[float] | None = None,
+    initial_price: float | None = None,
+    config: MarketGameConfig = DEFAULT_CONFIG,
+) -> SimulationResult:
+    """Run one 24-hour market-game episode."""
+    scenario = MarketScenario(
+        policies=policies,
+        demand_profile=demand_profile,
+        initial_price=initial_price,
+        config=config,
+    )
+    return run_scenario(scenario)
+
+
+def run_scenario(scenario: MarketScenario) -> SimulationResult:
+    """Run one complete market-game scenario."""
+    config = scenario.config
+    demand = list(scenario.demand_profile or config.demand_profile)
+    if len(demand) < config.episode_hours:
+        raise ValueError("scenario demand_profile must contain at least episode_hours values")
+    current_price = config.initial_price if scenario.initial_price is None else scenario.initial_price
+    if isinstance(current_price, bool) or not isinstance(current_price, (int, float)):
+        raise ValueError("scenario initial_price must be numeric")
+    if not math.isfinite(float(current_price)):
+        raise ValueError("scenario initial_price must be finite")
+    houses = []
+    for policy in scenario.policies:
+        reset = getattr(policy, "reset", None)
+        if reset is not None:
+            reset()
+        houses.append(
+            SimHouse(
+                policy=policy,
+                demand=list(demand),
+                battery=BatteryState(config.initial_battery, config),
+            )
+        )
+    price_history: list[float] = []
+    records: list[HourRecord] = []
+
+    for hour in range(config.episode_hours):
+        price_history.append(current_price)
+        hour_inputs: list[HouseHourInput] = []
+        for house in houses:
+            base_demand = house.demand[hour]
+            proposed_load = house.policy.compute_demand(
+                current_price,
+                hour,
+                house.battery.energy,
+                house.demand,
+                price_history,
+            )
+            hour_inputs.append(
+                HouseHourInput(
+                    name=house.policy.name,
+                    proposed_market_load=proposed_load,
+                    base_demand=base_demand,
+                    battery=house.battery,
+                )
+            )
+
+        record, house_results = step_market_hour(
+            hour=hour,
+            price=current_price,
+            house_inputs=hour_inputs,
+            config=config,
+        )
+        for house, result in zip(houses, house_results):
+            if result.warning:
+                house.boundary_warnings.append(result.warning)
+            if result.market_load != result.proposed_market_load:
+                house.clamps += 1
+            house.loads.append(result.market_load)
+            house.costs.append(result.cost)
+            house.battery_history.append(result.battery_charge)
+        records.append(record)
+        current_price = record.next_price
+
+    return SimulationResult(houses=houses, records=records, price_history=price_history)
+
+
+def step_market_hour(
+    hour: int,
+    price: float,
+    house_inputs: list[HouseHourInput],
+    config: MarketGameConfig = DEFAULT_CONFIG,
+) -> tuple[HourRecord, list[HouseHourResult]]:
+    """Validate submitted loads, update batteries, and compute next price."""
+    if isinstance(price, bool) or not isinstance(price, (int, float)):
+        raise ValueError("price must be numeric")
+    if not math.isfinite(float(price)):
+        raise ValueError("price must be finite")
+    house_results: list[HouseHourResult] = []
+    total_market_load = 0.0
+    for item in house_inputs:
+        clamp = clamp_market_load(
+            item.proposed_market_load,
+            item.base_demand,
+            item.battery.energy,
+            config,
+        )
+        market_load = clamp.market_load
+        item.battery.change(market_load - item.base_demand)
+        energy_cost = price * market_load
+        invalid_load_adjustment = abs(item.proposed_market_load - market_load)
+        penalty_cost = 20.0 * invalid_load_adjustment if clamp.warning else 0.0
+        cost = energy_cost + penalty_cost
+        total_market_load += market_load
+        house_results.append(
+            HouseHourResult(
+                name=item.name,
+                proposed_market_load=item.proposed_market_load,
+                market_load=market_load,
+                base_demand=item.base_demand,
+                battery_charge=item.battery.energy,
+                cost=cost,
+                energy_cost=energy_cost,
+                penalty_cost=penalty_cost,
+                invalid_load_adjustment=invalid_load_adjustment,
+                warning=clamp.warning,
+            )
+        )
+
+    house_count = len(house_inputs)
+    average_market_load = total_market_load / house_count if house_count else 0.0
+    next_price = compute_price_from_average_load(average_market_load) if house_count else 0.1
+    record = HourRecord(
+        hour=hour,
+        price=price,
+        total_load=total_market_load,
+        average_load=average_market_load,
+        next_price=next_price,
+        loads_by_house={result.name: result.market_load for result in house_results},
+        batteries_by_house={result.name: result.battery_charge for result in house_results},
+        costs_by_house={result.name: result.cost for result in house_results},
+        energy_costs_by_house={result.name: result.energy_cost for result in house_results},
+        penalties_by_house={
+            result.name: result.penalty_cost for result in house_results if result.penalty_cost
+        },
+        invalid_load_adjustments_by_house={
+            result.name: result.invalid_load_adjustment
+            for result in house_results
+            if result.invalid_load_adjustment
+        },
+        proposed_loads_by_house={
+            result.name: result.proposed_market_load for result in house_results
+        },
+        warnings_by_house={
+            result.name: result.warning for result in house_results if result.warning
+        },
+    )
+    return record, house_results

--- a/python/market_game/tests/check_simulation.py
+++ b/python/market_game/tests/check_simulation.py
@@ -1,0 +1,25 @@
+"""Run all pure-Python market-game simulation checks."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+
+TESTS_DIR = Path(__file__).resolve().parent
+if str(TESTS_DIR) not in sys.path:
+    sys.path.insert(0, str(TESTS_DIR))
+
+from check_simulation_core import run_check as run_core_check
+from check_simulation_parity import run_check as run_parity_check
+
+
+def run_check() -> None:
+    run_core_check()
+    print("simulation core: ok")
+    run_parity_check()
+    print("simulation parity: ok")
+
+
+if __name__ == "__main__":
+    run_check()

--- a/python/market_game/tests/check_simulation_core.py
+++ b/python/market_game/tests/check_simulation_core.py
@@ -1,0 +1,199 @@
+"""Checks for the dependency-free market-game simulation helpers."""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+import sys
+
+
+MARKET_GAME_DIR = Path(__file__).resolve().parents[1]
+if str(MARKET_GAME_DIR) not in sys.path:
+    sys.path.insert(0, str(MARKET_GAME_DIR))
+
+from simulation import BatteryAction, action_to_market_load
+from simulation.config import MarketGameConfig, demand_profile
+from simulation.rules import check_valid, compute_price_from_total_load, ensure_valid
+from simulation.simulator import (
+    BatteryState,
+    HouseHourInput,
+    MarketScenario,
+    run_scenario,
+    step_market_hour,
+)
+
+
+def run_check() -> None:
+    assert compute_price_from_total_load(15.0, 3) == 0.16
+    assert demand_profile("profile1")[0:4] == [2, 1, 1, 1]
+    assert demand_profile("flat") == [5] * 24
+    try:
+        demand_profile("typo")
+    except ValueError as exc:
+        assert "unknown demand profile" in str(exc)
+    else:
+        raise AssertionError("unknown demand profile was not rejected")
+
+    try:
+        MarketGameConfig(episode_hours=25, demand_profile=[1.0] * 24)
+    except ValueError as exc:
+        assert "demand_profile" in str(exc)
+    else:
+        raise AssertionError("short demand profile was not rejected")
+
+    try:
+        compute_price_from_total_load(math.nan, 1)
+    except ValueError as exc:
+        assert "total_market_load" in str(exc)
+    else:
+        raise AssertionError("non-finite total load was not rejected")
+
+    battery = BatteryState(0.0)
+    try:
+        battery.change(math.nan)
+    except ValueError as exc:
+        assert "battery delta" in str(exc)
+    else:
+        raise AssertionError("non-finite battery delta was not rejected")
+
+    assert check_valid(-1.0, 2.0, battery) == "listed consumption exceeds available battery energy"
+    assert ensure_valid(-1.0, 2.0, battery) == 2.0
+    assert action_to_market_load(BatteryAction.CHARGE, 2.0, 0.0) == 7.0
+    assert action_to_market_load(BatteryAction.DISCHARGE, 2.0, 0.0) == 2.0
+    assert MarketScenario(policies=[]).config.episode_hours == 24
+
+    battery = BatteryState(0.0)
+    record, results = step_market_hour(
+        hour=0,
+        price=0.5,
+        house_inputs=[
+            HouseHourInput(
+                name="test",
+                proposed_market_load=-1.0,
+                base_demand=2.0,
+                battery=battery,
+            )
+        ],
+    )
+    assert results[0].proposed_market_load == -1.0
+    assert results[0].market_load == 2.0
+    assert record.proposed_loads_by_house["test"] == -1.0
+    assert record.loads_by_house["test"] == 2.0
+    assert results[0].energy_cost == 1.0
+    assert results[0].penalty_cost == 60.0
+    assert results[0].invalid_load_adjustment == 3.0
+    assert results[0].cost == 61.0
+    assert record.energy_costs_by_house["test"] == 1.0
+    assert record.penalties_by_house["test"] == 60.0
+    assert record.invalid_load_adjustments_by_house["test"] == 3.0
+    assert record.warnings_by_house["test"] == "listed consumption exceeds available battery energy"
+
+    battery = BatteryState(0.0)
+    _, results = step_market_hour(
+        hour=0,
+        price=0.5,
+        house_inputs=[
+            HouseHourInput(
+                name="over_charge_rate",
+                proposed_market_load=100.0,
+                base_demand=2.0,
+                battery=battery,
+            )
+        ],
+    )
+    assert results[0].market_load == 7.0
+    assert battery.energy == 5.0
+    assert results[0].warning == "listed battery charge rate exceeds maximum charge rate"
+    assert results[0].penalty_cost == 1860.0
+    assert results[0].invalid_load_adjustment == 93.0
+
+    battery = BatteryState(19.0)
+    _, results = step_market_hour(
+        hour=0,
+        price=0.5,
+        house_inputs=[
+            HouseHourInput(
+                name="over_capacity",
+                proposed_market_load=100.0,
+                base_demand=2.0,
+                battery=battery,
+            )
+        ],
+    )
+    assert results[0].market_load == 3.0
+    assert battery.energy == 20.0
+    assert results[0].warning == "listed battery charge rate exceeds available battery storage capacity"
+
+    battery = BatteryState(20.0)
+    _, results = step_market_hour(
+        hour=0,
+        price=0.5,
+        house_inputs=[
+            HouseHourInput(
+                name="over_discharge_rate",
+                proposed_market_load=-100.0,
+                base_demand=12.0,
+                battery=battery,
+            )
+        ],
+    )
+    assert results[0].market_load == 2.0
+    assert battery.energy == 10.0
+    assert results[0].warning == "listed consumption exceeds max battery discharge rate"
+    assert results[0].penalty_cost == 2040.0
+    assert results[0].invalid_load_adjustment == 102.0
+
+    battery = BatteryState(0.0)
+    _, results = step_market_hour(
+        hour=0,
+        price=0.5,
+        house_inputs=[
+            HouseHourInput(
+                name="exact_charge_boundary",
+                proposed_market_load=7.0,
+                base_demand=2.0,
+                battery=battery,
+            )
+        ],
+    )
+    assert results[0].market_load == 7.0
+    assert results[0].warning == ""
+    assert results[0].penalty_cost == 0.0
+    assert results[0].invalid_load_adjustment == 0.0
+
+    try:
+        step_market_hour(hour=0, price=math.nan, house_inputs=[])
+    except ValueError as exc:
+        assert "price" in str(exc)
+    else:
+        raise AssertionError("non-finite market price was not rejected")
+
+    try:
+        step_market_hour(
+            hour=0,
+            price=0.5,
+            house_inputs=[
+                HouseHourInput(
+                    name="test",
+                    proposed_market_load=math.nan,
+                    base_demand=2.0,
+                    battery=BatteryState(0.0),
+                )
+            ],
+        )
+    except ValueError as exc:
+        assert "market_load" in str(exc)
+    else:
+        raise AssertionError("non-finite market load was not rejected")
+
+    try:
+        run_scenario(MarketScenario(policies=[], demand_profile=[1.0]))
+    except ValueError as exc:
+        assert "demand_profile" in str(exc)
+    else:
+        raise AssertionError("short scenario demand profile was not rejected")
+
+
+if __name__ == "__main__":
+    run_check()
+    print("simulation core: ok")

--- a/python/market_game/tests/check_simulation_parity.py
+++ b/python/market_game/tests/check_simulation_parity.py
@@ -1,0 +1,146 @@
+"""Parity checks for the pure-Python market-game simulator."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import sys
+
+
+MARKET_GAME_DIR = Path(__file__).resolve().parents[1]
+if str(MARKET_GAME_DIR) not in sys.path:
+    sys.path.insert(0, str(MARKET_GAME_DIR))
+
+from simulation.config import DEFAULT_CONFIG
+from simulation.simulator import run_episode
+
+
+BATTERY_CAPACITY = DEFAULT_CONFIG.battery_capacity
+BATTERY_MAX_CHARGE = DEFAULT_CONFIG.max_charge
+BATTERY_MAX_DISCHARGE = DEFAULT_CONFIG.max_discharge
+
+
+@dataclass
+class FlattenDemandPolicy:
+    name: str = "FlattenDemandHouse"
+
+    def reset(self) -> None:
+        pass
+
+    def compute_demand(
+        self,
+        price: float,
+        hour: int,
+        battery_charge: float,
+        demand: list[float],
+        price_history: list[float],
+    ) -> float:
+        del price, price_history
+        base_demand = demand[hour]
+        target_demand = sum(demand) / len(demand)
+        desired_change = target_demand - base_demand
+        if desired_change > 0.0:
+            charge_amount = min(
+                desired_change,
+                BATTERY_MAX_CHARGE,
+                BATTERY_CAPACITY - battery_charge,
+            )
+            return base_demand + charge_amount
+        discharge_amount = min(abs(desired_change), BATTERY_MAX_DISCHARGE, battery_charge)
+        return base_demand - discharge_amount
+
+
+@dataclass
+class FullCyclePolicy:
+    name: str = "FullCycleHouse"
+    charging: bool = True
+
+    def reset(self) -> None:
+        self.charging = True
+
+    def compute_demand(
+        self,
+        price: float,
+        hour: int,
+        battery_charge: float,
+        demand: list[float],
+        price_history: list[float],
+    ) -> float:
+        del price, price_history
+        if self.charging and battery_charge >= BATTERY_CAPACITY:
+            self.charging = False
+        elif (not self.charging) and battery_charge <= 0.0:
+            self.charging = True
+        if self.charging:
+            charge_amount = min(BATTERY_MAX_CHARGE, BATTERY_CAPACITY - battery_charge)
+            return demand[hour] + charge_amount
+        discharge_amount = min(BATTERY_MAX_DISCHARGE, battery_charge)
+        return demand[hour] - discharge_amount
+
+
+@dataclass
+class PriceAwarePolicy:
+    name: str = "PriceAwareHouse"
+
+    def reset(self) -> None:
+        pass
+
+    def reserve_target(self, hour: int) -> float:
+        if hour < 12:
+            return 4.0
+        if hour < 18:
+            return 8.0
+        if hour < 21:
+            return 3.0
+        return 0.0
+
+    def compute_demand(
+        self,
+        price: float,
+        hour: int,
+        battery_charge: float,
+        demand: list[float],
+        price_history: list[float],
+    ) -> float:
+        del price_history
+        base_demand = demand[hour]
+        remaining_capacity = BATTERY_CAPACITY - battery_charge
+        reserve = self.reserve_target(hour)
+        available_discharge = max(0.0, battery_charge - reserve)
+        if price <= 0.12:
+            charge_amount = min(BATTERY_MAX_CHARGE, remaining_capacity)
+            return base_demand + charge_amount
+        if price <= 0.19 and battery_charge < reserve:
+            charge_amount = min(BATTERY_MAX_CHARGE, remaining_capacity, reserve - battery_charge)
+            return base_demand + charge_amount
+        if price >= 0.49:
+            discharge_amount = min(BATTERY_MAX_DISCHARGE, battery_charge)
+            return base_demand - discharge_amount
+        if price >= 0.25 and available_discharge > 0.0:
+            discharge_amount = min(BATTERY_MAX_DISCHARGE, available_discharge)
+            return base_demand - discharge_amount
+        if hour >= 21 and battery_charge > 0.0:
+            discharge_amount = min(BATTERY_MAX_DISCHARGE, battery_charge)
+            return base_demand - discharge_amount
+        return base_demand
+
+
+EXPECTED_STOCK = {
+    "FlattenDemandHouse": (127.0, 35.446666666666665, 7.0),
+    "FullCycleHouse": (120.0, 47.74666666666667, 0.0),
+    "PriceAwareHouse": (125.0, 21.953333333333333, 5.0),
+}
+
+
+def run_check() -> None:
+    result = run_episode([FlattenDemandPolicy(), FullCyclePolicy(), PriceAwarePolicy()])
+    for house in result.houses:
+        expected_load, expected_cost, expected_battery = EXPECTED_STOCK[house.policy.name]
+        assert abs(house.total_load - expected_load) < 1e-9, house.policy.name
+        assert abs(house.total_cost - expected_cost) < 1e-9, house.policy.name
+        assert abs(house.battery.energy - expected_battery) < 1e-9, house.policy.name
+
+
+if __name__ == "__main__":
+    run_check()
+    print("simulation parity: ok")


### PR DESCRIPTION
## Summary

Adds a dependency-free pure-Python simulator for the market game, plus focused checks that validate rule behavior and parity with the stock example houses.

This does not change the HELICS runtime path. The existing `market_maker.py`, `battery.py`, and house federates continue to run the official co-simulation. The new simulator provides a fast local path for checking market-game rules, battery constraints, invalid-demand penalties, and expected strategy outcomes without starting HELICS federates.

## What Changed

- Added `python/market_game/simulation/`
  - `config.py`: market-game constants and demand profiles
  - `rules.py`: price calculation, battery clamping, and validation helpers
  - `simulator.py`: 24-hour pure-Python episode runner
- Added simulator documentation:
  - `python/market_game/docs/simulation.md`
  - `python/market_game/simulation/README.md`
- Added focused checks:
  - `python/market_game/tests/check_simulation.py`
  - `python/market_game/tests/check_simulation_core.py`
  - `python/market_game/tests/check_simulation_parity.py`
- Updated `python/market_game/market_game.md` to mention the simulator checks and docs.

## Parity Coverage

The parity check verifies the expected 24-hour totals for the stock example houses:

| House | Total market load | Total cost | Final battery |
|---|---:|---:|---:|
| `FlattenDemandHouse` | `127.0` | `$35.4467` | `7.0` |
| `FullCycleHouse` | `120.0` | `$47.7467` | `0.0` |
| `PriceAwareHouse` | `125.0` | `$21.9533` | `5.0` |

## Validation

Tested with:

```bash
python3 python/market_game/tests/check_simulation.py
python3 python/market_game/tests/check_battery_validation.py
git diff --cached --check
```
